### PR TITLE
Feature san002

### DIFF
--- a/src/controllers/sanitaryRegister.controller.js
+++ b/src/controllers/sanitaryRegister.controller.js
@@ -36,9 +36,10 @@ module.exports = {
   },
   async update(req, res) {
     try {
-      const { sanitaryRegisterId } = req.params;
+      const client = await Client.findById(req.client)
+      const sanitaryRegisterId = client.sanitaryRegister
       const sanitaryRegister = await SanitaryRegister
-        .findByIdAndUpdate(sanitaryRegisterId, req.body, { new: true })
+        .findByIdAndUpdate(sanitaryRegisterId, req.body, { new: true, useFindAndModify: false, })
       if(!sanitaryRegister) {
         throw new Error('Could not update that sanitary register')
       }

--- a/src/controllers/sanitaryRegister.controller.js
+++ b/src/controllers/sanitaryRegister.controller.js
@@ -3,8 +3,9 @@ const Client = require('../models/client.model');
 
 module.exports = {
   async show(req, res) {
-    const { sanitaryRegisterId } = req.params;
     try {
+      const client = await Client.findById(req.client)
+      const sanitaryRegisterId = client.sanitaryRegister
       const sanitaryRegister = await SanitaryRegister
         .findById(sanitaryRegisterId)
         .populate({ path: 'user', select: 'name'})

--- a/src/routes/sanitaryRegister.js
+++ b/src/routes/sanitaryRegister.js
@@ -4,6 +4,6 @@ const { auth } = require('../utils/auth');
 
 router.route('/').post(auth, sanitaryRegisterController.create);
 router.route('/').get(auth, sanitaryRegisterController.show);
-router.route('/:sanitaryRegisterId').put(auth, sanitaryRegisterController.update);
+router.route('/').put(auth, sanitaryRegisterController.update);
 
 module.exports = router

--- a/src/routes/sanitaryRegister.js
+++ b/src/routes/sanitaryRegister.js
@@ -3,7 +3,7 @@ const sanitaryRegisterController = require('../controllers/sanitaryRegister.cont
 const { auth } = require('../utils/auth');
 
 router.route('/').post(auth, sanitaryRegisterController.create);
-router.route('/:sanitaryRegisterId').get(auth, sanitaryRegisterController.show);
+router.route('/').get(auth, sanitaryRegisterController.show);
 router.route('/:sanitaryRegisterId').put(auth, sanitaryRegisterController.update);
 
 module.exports = router


### PR DESCRIPTION
**Change the id for sanitary with the auth client**

**files change**

> sanitaryRegister.controller.js -> change the id from params to auth client for update and get

> sanitaryRegister.js -> delete the id for the path

**Aditional add useFindAndModify: false because the mongoose have deprecated and show the warning

_**

> (node:23511) DeprecationWarning: Mongoose: `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false are deprecated. See: https://mongoosejs.com/docs/deprecations.html#findandmodify

_